### PR TITLE
fix: reload Lua scripts after Redis NOSCRIPT

### DIFF
--- a/src/lua/loader.ts
+++ b/src/lua/loader.ts
@@ -80,6 +80,20 @@ export async function evalScript<T = any>(
   argv: Array<string>,
   numKeys: number,
 ): Promise<T> {
-  const sha = await loadScript(client, name);
-  return (client as any).evalsha(sha, numKeys, ...argv);
+  const runEvalSha = async () => {
+    const sha = await loadScript(client, name);
+    return (client as any).evalsha(sha, numKeys, ...argv) as Promise<T>;
+  };
+
+  try {
+    return await runEvalSha();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!message.includes('NOSCRIPT')) {
+      throw error;
+    }
+
+    cacheByClient.get(client)?.delete(name);
+    return await runEvalSha();
+  }
 }

--- a/test/lua-loader.test.ts
+++ b/test/lua-loader.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { evalScript } from '../src/lua/loader';
+
+describe('Lua script loader', () => {
+  it('reloads and retries once when Redis returns NOSCRIPT', async () => {
+    let loadCount = 0;
+    const evalshaCalls: string[] = [];
+    const redis = {
+      script: async (command: string) => {
+        expect(command).toBe('load');
+        loadCount += 1;
+        return `sha-${loadCount}`;
+      },
+      evalsha: async (sha: string) => {
+        evalshaCalls.push(sha);
+        if (evalshaCalls.length === 1) {
+          throw new Error('NOSCRIPT No matching script. Please use EVAL.');
+        }
+        return 'ok';
+      },
+    };
+
+    await expect(
+      evalScript(redis as any, 'enqueue', ['test-namespace'], 1),
+    ).resolves.toBe('ok');
+
+    expect(loadCount).toBe(2);
+    expect(evalshaCalls).toEqual(['sha-1', 'sha-2']);
+  });
+
+  it('does not retry non-NOSCRIPT Redis errors', async () => {
+    let loadCount = 0;
+    const redis = {
+      script: async () => {
+        loadCount += 1;
+        return `sha-${loadCount}`;
+      },
+      evalsha: async () => {
+        throw new Error('READONLY You cannot write against a read only replica.');
+      },
+    };
+
+    await expect(
+      evalScript(redis as any, 'enqueue', ['test-namespace'], 1),
+    ).rejects.toThrow('READONLY');
+
+    expect(loadCount).toBe(1);
+  });
+});

--- a/test/queue.redis-disconnect.test.ts
+++ b/test/queue.redis-disconnect.test.ts
@@ -114,6 +114,25 @@ describe('Redis Disconnect/Reconnect Tests', () => {
     await redis.quit();
   });
 
+  it('should reload cached Lua scripts after Redis SCRIPT FLUSH', async () => {
+    const redis = new Redis(REDIS_URL);
+    const q = new Queue({ redis, namespace: `${namespace}:script-flush` });
+
+    await q.add({ groupId: 'script-flush-group', data: { phase: 'before' } });
+
+    // Redis does not persist its Lua script cache across restarts/failovers.
+    // SCRIPT FLUSH reproduces the NOSCRIPT condition without restarting Redis.
+    await (redis as any).script('flush');
+
+    await expect(
+      q.add({ groupId: 'script-flush-group', data: { phase: 'after' } }),
+    ).resolves.toBeDefined();
+
+    expect(await q.getWaitingCount()).toBe(2);
+
+    await redis.quit();
+  });
+
   it('should handle network partitions and blocking operations', async () => {
     const redis = new Redis(REDIS_URL, {
       connectTimeout: 1000,


### PR DESCRIPTION
## Summary\n- retry GroupMQ Lua evals once when Redis returns NOSCRIPT\n- clear the stale client-side SHA cache before reloading the script\n- add unit coverage for retry and non-NOSCRIPT error behavior\n- add an integration regression for SCRIPT FLUSH with a real Redis connection\n\n## Context\nRedis Lua script cache is volatile across restarts, failovers, and SCRIPT FLUSH. GroupMQ caches SCRIPT LOAD SHA values client-side, so a stale SHA can make every queue operation fail until the process restarts.\n\n## Verification\n- npx pnpm@10.18.3 exec vitest run test/lua-loader.test.ts\n- npx pnpm@10.18.3 run build\n\nNote: full typecheck currently fails on existing queue.corrupted-jobs.test.ts typing errors unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Lua script execution is now resilient to script cache misses with automatic reload and retry functionality.

* **Tests**
  * Added comprehensive test coverage for script cache miss scenarios and error handling validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Openpanel-dev/groupmq/pull/17?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->